### PR TITLE
Fix bugs preventing use in Firefox

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,11 +38,11 @@ class App extends Component {
     return (
       <div className="App">
         <nav className="navbar pure-menu pure-menu-horizontal">
-          <Link to="/" className="pure-menu-heading pure-menu-link">Truffle Box</Link>
           <ul className="pure-menu-list navbar-right">
             <OnlyGuestLinks />
             <OnlyAuthLinks />
           </ul>
+          <Link to="/" className="pure-menu-heading pure-menu-link">Truffle Box</Link>
         </nav>
 
         {this.props.children}

--- a/src/user/ui/signupform/SignUpFormContainer.js
+++ b/src/user/ui/signupform/SignUpFormContainer.js
@@ -9,8 +9,6 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     onSignUpFormSubmit: (name) => {
-      event.preventDefault();
-
       dispatch(signUpUser(name))
     }
   }


### PR DESCRIPTION
# Event Fix
Firefox throws an error whenever a user clicks the "Sign Up" button that reads "ReferenceError: event is not found." This is fixed by removing a reference to the undefined "event" in SignUpFormContainer. This doesn't throw an error in Chrome or IE because both have a global symbol for "event".  The SignUpForm container already handles preventing event defaults anyway.

# UI Fix
Firefox causes an unwanted line break in the menu as shown in the image below. This is due to the right floated elements in the menu. A simple fix is to switch the menu elements so that the floated element comes first followed by the elements still within the flow of the page. 

![image](https://user-images.githubusercontent.com/7053459/28447784-239d36d4-6da1-11e7-982f-662aa2fcc246.png)
