### PR TITLE
Update contracts/Authentication.sol:::

### DIFF
--- a/contracts/Authentication.sol
+++ b/contracts/Authentication.sol
@@ -11,30 +11,34 @@ contract Authentication is Killable {
 
   uint private id; // Stores user id temporarily
 
-  function login() constant returns (bytes32) {
-    // Check if user exists.
-    // If yes, return user.
-    // If no, throw.
+  modifier onlyExistingUser {
+    // Check if user exists or terminate
 
-    if (users[msg.sender].name == 0x0)
-    {
-        throw;
-    }
+    require(!(users[msg.sender].name == 0x0));
+    _;
+  }
 
+  modifier onlyValidName(bytes32 name) {
+    // Only valid names allowed
+
+    require(!(name == 0x0));
+    _;
+  }
+
+  function login() constant
+  onlyExistingUser
+  returns (bytes32) {
     return (users[msg.sender].name);
   }
 
-  function signup(bytes32 name) payable returns (bytes32) {
+  function signup(bytes32 name)
+  payable
+  onlyValidName(name)
+  returns (bytes32) {
     // Check if user exists.
     // If yes, return user name.
     // If no, check if name was sent.
     // If yes, create and return user.
-    // If no, throw.
-
-    if (name == 0x0)
-    {
-        throw;
-    }
 
     if (users[msg.sender].name == 0x0)
     {
@@ -46,13 +50,12 @@ contract Authentication is Killable {
     return (users[msg.sender].name);
   }
 
-  function update(bytes32 name) payable returns (bytes32) {
+  function update(bytes32 name)
+  payable
+  onlyValidName(name)
+  onlyExistingUser
+  returns (bytes32) {
     // Update user name.
-
-    if (name == 0x0)
-    {
-        throw;
-    }
 
     if (users[msg.sender].name != 0x0)
     {
@@ -60,7 +63,5 @@ contract Authentication is Killable {
 
         return (users[msg.sender].name);
     }
-
-    throw;
   }
 }


### PR DESCRIPTION
Use Modifier [onlyExistingUser] to ensure that only existing users can login.
Use Modifier [onlyValidName] to ensure names are sent when signing up.
Use the two modifiers [onlyExisitingUser and onlyValidName] to ensure safe update.

The use of modifiers is to conform to the warning that throw is deprecated in favour of
"revert()", "require()", and "assert()".