### PR TITLE
Upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build_webpack
 .env
 npm-debug.log
 .truffle-solidity-loader
+package-lock.json

--- a/contracts/Authentication.sol
+++ b/contracts/Authentication.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity 0.4.18;
 
 import './zeppelin/lifecycle/Killable.sol';
 

--- a/contracts/Authentication.sol
+++ b/contracts/Authentication.sol
@@ -25,8 +25,9 @@ contract Authentication is Killable {
     _;
   }
 
-  function login() constant
+  function login()
   public
+  view
   onlyExistingUser
   returns (bytes32) {
     return (users[msg.sender].name);

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity 0.4.18;
 
 contract Migrations {
   address public owner;

--- a/contracts/zeppelin/lifecycle/Killable.sol
+++ b/contracts/zeppelin/lifecycle/Killable.sol
@@ -9,7 +9,7 @@ import "./../ownership/Ownable.sol";
  * Base contract that can be killed by owner. All funds in contract will be sent to the owner.
  */
 contract Killable is Ownable {
-  function kill() onlyOwner {
+  function kill() public onlyOwner {
     selfdestruct(owner);
   }
 }

--- a/contracts/zeppelin/lifecycle/Killable.sol
+++ b/contracts/zeppelin/lifecycle/Killable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity 0.4.18;
 
 
 import "./../ownership/Ownable.sol";

--- a/contracts/zeppelin/ownership/Ownable.sol
+++ b/contracts/zeppelin/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.4;
+pragma solidity 0.4.18;
 
 
 /*

--- a/contracts/zeppelin/ownership/Ownable.sol
+++ b/contracts/zeppelin/ownership/Ownable.sol
@@ -10,7 +10,7 @@ pragma solidity 0.4.18;
 contract Ownable {
   address public owner;
 
-  function Ownable() {
+  function Ownable() public {
     owner = msg.sender;
   }
 
@@ -19,7 +19,7 @@ contract Ownable {
       _;
   }
 
-  function transferOwnership(address newOwner) onlyOwner {
+  function transferOwnership(address newOwner) public onlyOwner {
     if (newOwner != address(0)) owner = newOwner;
   }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "recursive-readdir": "2.1.0",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
-    "truffle-contract": "^1.1.8",
+    "truffle-contract": "^3.0.0",
     "url-loader": "0.5.7",
     "webpack": "1.14.0",
     "webpack-dev-server": "1.16.2",


### PR DESCRIPTION
This PR
- upgrades truffle-contract to `v^3.0.0` so that users can take advantage of the new artifact format as stated in [Truffle 4's release page](https://github.com/trufflesuite/truffle/releases).
- Upgrades solidity compiler to Truffle 4's required `v0.4.18`, and explicitly states the version too.
- Adds visibility specification to the included zeppelin Smart Contracts.
- Replaces `constant` with `view` mutability state.