### PR TITLE
Remove event.preventDefault call

### DIFF
--- a/src/user/ui/profileform/ProfileFormContainer.js
+++ b/src/user/ui/profileform/ProfileFormContainer.js
@@ -11,8 +11,6 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     onProfileFormSubmit: (name) => {
-      event.preventDefault();
-
       dispatch(updateUser(name))
     }
   }


### PR DESCRIPTION
Problem: 

The onProfileFormSubmit function makes a redundant call to event.preventDefault()
- event.preventDefault is already called inside handleFormSubmit (src/user/ui/ProfileForm.js)
- event is never passed from the function which causes an error when trying to update the user name

Solution: removed the redundant event.preventDefault call